### PR TITLE
Update AnalogSensor getter to const and adjust sensor definitions

### DIFF
--- a/lib/AnalogSensor/AnalogSensorManager.h
+++ b/lib/AnalogSensor/AnalogSensorManager.h
@@ -10,6 +10,9 @@
 #include <ADC.h>
 #include <Config.h>
 
+#define MAX_NUM_OF_SENSORS DAQ_NUM_OF_SENSORS
+#define DEFAULT_ADC_RESOLUTION DAQ_ADC_RESOLUTION
+
 /**
  * @brief A class to manage and synchronize readings from multiple analog
  * sensors.

--- a/lib/AnalogSensor/AnalogSensorTypes.h
+++ b/lib/AnalogSensor/AnalogSensorTypes.h
@@ -94,5 +94,5 @@ public:
    * @param raw_data The raw sensor data.
    * @return The converted sensor value.
    */
-  virtual double getSensorData(int raw_data) = 0;
+  virtual const double getSensorData(int raw_data) const = 0;
 };

--- a/lib/AnalogSensor/AnalogSensorTypes.h
+++ b/lib/AnalogSensor/AnalogSensorTypes.h
@@ -9,9 +9,6 @@
 #include <Arduino.h>
 #include <Config.h>
 
-#define MAX_NUM_OF_SENSORS DAQ_NUM_OF_SENSORS
-#define DEFAULT_ADC_RESOLUTION DAQ_ADC_RESOLUTION
-
 /**
  * @brief A data structure that represents an analog sensor multiplexer.
  * @details This class is used to control the CD74HC4067 multiplexer.


### PR DESCRIPTION
Update AnalogSensor getter's type to const method, and move the sensor macro definition to the right file.